### PR TITLE
Fixed rand_test.c

### DIFF
--- a/test/rand_test.c
+++ b/test/rand_test.c
@@ -1,11 +1,12 @@
 #include <zeda/zeda_rand.h>
 #ifdef __unix__
 #include <unistd.h>
-#else
+#endif /* __unix__ */
+#include <zeda/zeda_rand.h>
+
 # if defined( __WINDOWS__ )
 # define sleep(s) Sleep( 1000 * (s) )
 # endif /* __WINDOWS__ */
-#endif /* __unix__ */
 
 void assert_rand_int_gen(int min, int max, int val[], int n)
 {

--- a/test/rand_test.c
+++ b/test/rand_test.c
@@ -1,3 +1,4 @@
+#include <zeda/zeda_rand.h>
 #ifdef __unix__
 #include <unistd.h>
 #else
@@ -5,7 +6,6 @@
 # define sleep(s) Sleep( 1000 * (s) )
 # endif /* __WINDOWS__ */
 #endif /* __unix__ */
-#include <zeda/zeda_rand.h>
 
 void assert_rand_int_gen(int min, int max, int val[], int n)
 {


### PR DESCRIPTION
rand_test.c failed to compile in windows environment.  
Fix the order to include zeda_rand.h first to use ``__WINDOWS__`` macro in rand_test.c.